### PR TITLE
Disable `carrier cost computation`(default behaviour)

### DIFF
--- a/carrier.py
+++ b/carrier.py
@@ -56,11 +56,12 @@ class Carrier:
 
         shipment = Transaction().context.get('shipment')
         sale = Transaction().context.get('sale')
+        usd, = Currency.search([('code', '=', 'USD')])  # Default currency
 
         if Transaction().context.get('ignore_carrier_computation'):
-            return Decimal('0'), None
+            return Decimal('0'), usd.id
         if not sale and not shipment:
-            return Decimal('0'), None
+            return Decimal('0'), usd.id
 
         if self.carrier_cost_method != 'endicia':
             return super(Carrier, self).get_sale_price()
@@ -72,7 +73,7 @@ class Carrier:
         if shipment:
             return Shipment(shipment).get_endicia_shipping_cost(), usd.id
 
-        return Decimal('0'), None
+        return Decimal('0'), usd.id
 
 
 class EndiciaMailclass(ModelSQL, ModelView):

--- a/sale.py
+++ b/sale.py
@@ -174,7 +174,11 @@ class Sale:
     def create_shipment(self, shipment_type):
         Shipment = Pool().get('stock.shipment.out')
 
-        shipments = super(Sale, self).create_shipment(shipment_type)
+        with Transaction().set_context(ignore_carrier_computation=True):
+            # disable `carrier cost computation`(default behaviour) as cost
+            # should only be computed after updating mailclass else error may
+            # occur, with improper mailclass.
+            shipments = super(Sale, self).create_shipment(shipment_type)
         if shipment_type == 'out' and shipments and self.carrier and \
                 self.carrier.carrier_cost_method == 'endicia':
             Shipment.write(shipments, {


### PR DESCRIPTION
Disable `carrier cost computation`(default behaviour) as cost
should only be computed after updating mailclass else
error may occur, with improper mailclass.
